### PR TITLE
Monkey patch mention_name to prepend '@' for Hipchat

### DIFF
--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -1,5 +1,6 @@
 require "lita"
 require "lita/adapters/hipchat/connector"
+require "lita/adapters/hipchat/user"
 
 module Lita
   module Adapters

--- a/lib/lita/adapters/hipchat/user.rb
+++ b/lib/lita/adapters/hipchat/user.rb
@@ -1,0 +1,12 @@
+module Lita
+  class User
+    # Monkey patch mention_name to prepend '@' for Hipchat
+    def mention_name
+      if metadata["mention_name"]
+        "@#{metadata['mention_name']}"
+      else
+        name
+      end
+    end
+  end
+end

--- a/spec/lita/adapters/hipchat/user_spec.rb
+++ b/spec/lita/adapters/hipchat/user_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+describe Lita::User, lita: true do
+  describe "#mention_name" do
+    it "returns the user's mention name from metadata" do
+      subject = described_class.new(1, name: "Carl", mention_name: "carlthepug")
+      expect(subject.mention_name).to eq("@carlthepug")
+    end
+
+    it "returns the user's name if there is no mention name in the metadata" do
+      subject = described_class.new(1, name: "Carl")
+      expect(subject.mention_name).to eq("Carl")
+    end
+  end
+end


### PR DESCRIPTION
Hipchat uses '@' in mention names, so automatically append that when the hipchat adapter is loaded.