### PR TITLE
First pass at re-joining persisted rooms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
+cache: bundler
 rvm:
-  - 2.0.0
+  - 2.0
+  - 2.1
+  - 2.2
 script: bundle exec rspec
 before_install:
   - gem update --system

--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -51,7 +51,7 @@ module Lita
       def join_persisted_rooms(robot)
         return unless robot.respond_to?(:persisted_rooms) && robot.persisted_rooms
         robot.persisted_rooms.each do |room|
-          join(room) rescue Lita.logger.debug "Error connecting to room: #{room}"
+          join(room)
         end
       end
 

--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -42,9 +42,17 @@ module Lita
         connector.connect
         robot.trigger(:connected)
         rooms.each { |r| join(r) }
+        join_persisted_rooms(robot)
         sleep
       rescue Interrupt
         shut_down
+      end
+
+      def join_persisted_rooms(robot)
+        return unless robot.respond_to?(:persisted_rooms) && robot.persisted_rooms
+        robot.persisted_rooms.each do |room|
+          join(room) rescue Lita.logger.debug "Error connecting to room: #{room}"
+        end
       end
 
       def send_messages(target, strings)

--- a/spec/lita/adapters/hipchat_spec.rb
+++ b/spec/lita/adapters/hipchat_spec.rb
@@ -41,13 +41,6 @@ describe Lita::Adapters::HipChat, lita: true do
       subject.join_persisted_rooms(robot)
     end
 
-    it "handles bad room names well" do
-      expect(robot).to receive(:respond_to?).and_return(true)
-      expect(robot).to receive(:persisted_rooms).twice.and_return(["bad_room_id"])
-      expect(subject).to receive(:join).with("bad_room_id").and_raise("foobar")
-      expect { subject.join_persisted_rooms(robot) }.to_not raise_exception
-    end
-
     it "handles empty persisted_rooms well" do
       expect(robot).to receive(:respond_to?).and_return(true)
       expect(robot).to receive(:persisted_rooms).twice.and_return([])


### PR DESCRIPTION
This is my first pass at re-joining persisted rooms, I think we need to move the persisted_rooms to not be private on Lita::Robot so that the adapter can access that list and re-join on start up. Once that is done I think we can start writing more tests around this and then it may be ready to merge.