### PR TITLE
Create rooms in redis on run Fixes #30

### DIFF
--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -42,6 +42,7 @@ module Lita
         connector.connect
         robot.trigger(:connected)
         join_persisted_rooms
+        create_room_objects
         sleep
       rescue Interrupt
         shut_down
@@ -66,6 +67,13 @@ module Lita
       end
 
       private
+
+      def create_room_objects
+        connector.list_rooms(muc_domain).each do |room|
+          room.sub!("@#{muc_domain}", '')
+          Room.create_or_update(room)
+        end
+      end
 
       def join_all_rooms?
         config.rooms == :all

--- a/spec/lita/adapters/hipchat_spec.rb
+++ b/spec/lita/adapters/hipchat_spec.rb
@@ -12,6 +12,7 @@ describe Lita::Adapters::HipChat, lita: true do
     end
 
     allow(described_class::Connector).to receive(:new).and_return(connector)
+    allow(connector).to receive(:list_rooms).and_return(rooms)
   end
 
   subject { described_class.new(robot) }
@@ -19,7 +20,7 @@ describe Lita::Adapters::HipChat, lita: true do
   let(:robot) { Lita::Robot.new(registry) }
   let(:connector) { instance_double("Lita::Adapters::HipChat::Connector") }
   let(:domain) { "conf.hipchat.com" }
-  let(:rooms) { %w(room_1, room_2) }
+  let(:rooms) { %w(room_1 room_2) }
 
   it "registers with Lita" do
     expect(Lita.adapters[:hipchat]).to eql(described_class)
@@ -64,6 +65,12 @@ describe Lita::Adapters::HipChat, lita: true do
     it "connects to HipChat" do
       expect(subject.connector).to receive(:connect)
       expect(robot).to receive(:trigger).with(:connected)
+      subject.run
+    end
+
+    it "creates room objects in redis" do
+      expect(Lita::Room).to receive(:create_or_update).with 'room_1'
+      expect(Lita::Room).to receive(:create_or_update).with 'room_2'
       subject.run
     end
 


### PR DESCRIPTION
Create/update the rooms in redis on run so that the rooms can be persisted. I had to strip the muc_domain from the room name since it appears that lita is persisting just based on the room name and the room list contains the muc_domain.